### PR TITLE
set the header Vary:Origin when the access-control-allow-origin is not *

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = function (options) {
 
       set(this, 'Access-Control-Allow-Origin', origin);
 
-      if (origin !== '*'){
+      if (origin !== '*') {
         set(this, 'Vary', 'Origin');
       }
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,11 @@ module.exports = function (options) {
       set(this, 'Access-Control-Allow-Origin', origin);
 
       if (origin !== '*') {
-        set(this, 'Vary', 'Origin');
+        if (!this.get('Vary')) {
+          set(this, 'Vary', 'Origin');
+        } else {
+          set(this, 'Vary', this.get('Vary') + ',Origin');
+        }
       }
 
       if (options.credentials === true) {

--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ module.exports = function (options) {
 
       set(this, 'Access-Control-Allow-Origin', origin);
 
+      if (origin !== '*'){
+        set(this, 'Vary', 'Origin');
+      }
+
       if (options.credentials === true) {
         set(this, 'Access-Control-Allow-Credentials', 'true');
       }
@@ -104,6 +108,10 @@ module.exports = function (options) {
       }
 
       set(this, 'Access-Control-Allow-Origin', origin);
+
+      if (origin !== '*'){
+        set(this, 'Vary', 'Origin');
+      }
 
       if (options.credentials === true) {
         set(this, 'Access-Control-Allow-Credentials', 'true');

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -42,6 +42,7 @@ describe('cors.test.js', function () {
       .set('Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
       .expect({foo: 'bar'})
+      .expect('Vary', 'Origin')
       .expect(200, done);
     });
 
@@ -52,6 +53,7 @@ describe('cors.test.js', function () {
       .set('Access-Control-Request-Method', 'PUT')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Methods', 'GET,HEAD,PUT,POST,DELETE')
+      .expect('Vary', 'Origin')
       .expect(204, done);
     });
 
@@ -374,6 +376,7 @@ describe('cors.test.js', function () {
       .get('/')
       .set('Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
+      .expect('Vary', 'Origin')
       .expect(/Error/)
       .expect(500, done);
     });
@@ -391,6 +394,7 @@ describe('cors.test.js', function () {
       .get('/')
       .set('Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
+      .expect('Vary', 'Origin')
       .expect(/Error/)
       .expect(500, function (err, res) {
         if (err) {


### PR DESCRIPTION
If the server specifies an origin host rather than "*", then it must also include Origin in the Vary response header to indicate to clients that server responses will differ based on the value of the Origin request header.[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Origin)
