### PR TITLE
append vary header Origin when Access-Allow-Origin is not *.

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,10 @@ module.exports = function(options) {
       // Simple Cross-Origin Request, Actual Request, and Redirects
       set('Access-Control-Allow-Origin', origin);
 
+      if (origin !== '*') {
+        ctx.vary('Origin');
+      }
+
       if (options.credentials === true) {
         set('Access-Control-Allow-Credentials', 'true');
       }
@@ -97,6 +101,10 @@ module.exports = function(options) {
       }
 
       ctx.set('Access-Control-Allow-Origin', origin);
+
+      if (origin !== '*') {
+        ctx.vary('Origin');
+      }
 
       if (options.credentials === true) {
         ctx.set('Access-Control-Allow-Credentials', 'true');

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -29,6 +29,7 @@ describe('cors.test.js', function() {
       .get('/')
       .set('Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
+      .expect('Vary', 'Origin')
       .expect({foo: 'bar'})
       .expect(200, done);
     });
@@ -40,6 +41,7 @@ describe('cors.test.js', function() {
       .set('Access-Control-Request-Method', 'PUT')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Methods', 'GET,HEAD,PUT,POST,DELETE,PATCH')
+      .expect('Vary', 'Origin')
       .expect(204, done);
     });
 
@@ -67,6 +69,40 @@ describe('cors.test.js', function() {
       .expect('Access-Control-Allow-Origin', '*')
       .expect({foo: 'bar'})
       .expect(200, done);
+    });
+
+    it('should 204 on Preflight Request', function(done) {
+      request(app.listen())
+      .options('/')
+      .set('Origin', 'http://koajs.com')
+      .set('Access-Control-Request-Method', 'PUT')
+      .expect('Access-Control-Allow-Origin', '*')
+      .expect('Access-Control-Allow-Methods', 'GET,HEAD,PUT,POST,DELETE,PATCH')
+      .expect(204, done);
+    });
+  });
+
+  describe('options.origin=http://koajs.com', function() {
+    const app = new Koa();
+    app.use(function(ctx, next) {
+      ctx.set('Vary', 'X-Vary-Header');
+      return next();
+    });
+    app.use(cors({
+      origin: 'http://koajs.com',
+    }));
+    app.use(function(ctx) {
+      ctx.body = {foo: 'bar'};
+    });
+
+    it('should append Vary header when already has a Vary header', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect('Access-Control-Allow-Origin', 'http://koajs.com')
+        .expect('Vary', 'X-Vary-Header, Origin')
+        .expect({foo: 'bar'})
+        .expect(200, done);
     });
   });
 


### PR DESCRIPTION
According to [MDN Access_control_CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS), it says If the server specifies an origin host rather than "*", then it must also include Origin in the Vary response header to indicate to clients that server responses will differ based on the value of the Origin request header. I don't know where to add doc for this.
