### PR TITLE
Skip request if origin is not allowed

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function(options) {
       // FIXME: origin can be promise
       origin = options.origin(ctx);
       if (!origin) {
-        return next();
+        return;
       }
     } else {
       origin = options.origin || requestOrigin;
@@ -99,7 +99,7 @@ module.exports = function(options) {
       // The request is outside the scope of this specification.
       if (!ctx.get('Access-Control-Request-Method')) {
         // this not preflight request, ignore it
-        return next();
+        return;
       }
 
       ctx.set('Access-Control-Allow-Origin', origin);

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -43,11 +43,11 @@ describe('cors.test.js', function() {
       .expect(204, done);
     });
 
-    it('should not Preflight Request if request missing Access-Control-Request-Method', function(done) {
+    it('should skip if request missing Access-Control-Request-Method', function(done) {
       request(app.listen())
       .options('/')
       .set('Origin', 'http://koajs.com')
-      .expect(200, done);
+      .expect(404, done);
     });
 
     it('should always set `Vary` to Origin', function(done) {
@@ -83,7 +83,7 @@ describe('cors.test.js', function() {
     const app = new Koa();
     app.use(cors({
       origin: function(ctx) {
-        if (ctx.url === '/forbin') {
+        if (ctx.get('origin') === 'forbin') {
           return false;
         }
         return '*';
@@ -93,16 +93,11 @@ describe('cors.test.js', function() {
       ctx.body = {foo: 'bar'};
     });
 
-    it('should disable cors', function(done) {
+    it('should skip if origin not allowed', function(done) {
       request(app.listen())
       .get('/forbin')
-      .set('Origin', 'http://koajs.com')
-      .expect({foo: 'bar'})
-      .expect(200, function(err, res) {
-        assert(!err);
-        assert(!res.headers['access-control-allow-origin']);
-        done();
-      });
+      .set('Origin', 'forbin')
+      .expect(404, done);
     });
 
     it('should set access-control-allow-origin to *', function(done) {


### PR DESCRIPTION
Requests are currently going through even if the origin is not allowed.