### PR TITLE
Set `Vary: Origin` header on error responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
 'use strict';
 
-function getVaryHeaderPrefix(headers) {
-  const vary = headers.vary || headers.Vary;
-  if (vary && vary.search(/origin/i) === -1 && vary.indexOf('*') === -1) {
-    return vary + ', ';
-  }
-  return '';
-}
+const vary = require('vary');
 
 /**
  * CORS middleware
@@ -97,7 +91,7 @@ module.exports = function(options) {
       }
       return next().catch(err => {
         const errHeadersSet = err.headers || {};
-        const varyWithOrigin = getVaryHeaderPrefix(errHeadersSet) + 'Origin';
+        const varyWithOrigin = vary.append(errHeadersSet.vary || errHeadersSet.Vary || '', 'Origin');
         delete errHeadersSet.Vary;
 
         err.headers = Object.assign({}, errHeadersSet, headersSet, {vary: varyWithOrigin});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint index.js test",
     "autod": "autod -w --prefix '^'"
   },
-  "dependencies": {},
+  "dependencies": {
+    "vary": "^1.1.2"
+  },
   "devDependencies": {
     "autod": "*",
     "eslint": "^2.3.0",

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -335,6 +335,7 @@ describe('cors.test.js', function() {
       .get('/')
       .set('Origin', 'http://koajs.com')
       .expect('Access-Control-Allow-Origin', 'http://koajs.com')
+      .expect('Vary', 'Origin')
       .expect(/Error/)
       .expect(500, done);
     });
@@ -397,6 +398,7 @@ describe('cors.test.js', function() {
           return done(err);
         }
         assert(!res.headers['access-control-allow-origin']);
+        assert(!res.headers['vary']);
         done();
       });
     });
@@ -422,6 +424,24 @@ describe('cors.test.js', function() {
       .expect('Vary', 'Accept-Encoding, Origin')
       .expect({foo: 'bar'})
       .expect(200, done);
+    });
+    it('should append `Vary` header to an error', function(done) {
+      const app = new Koa();
+      app.use(cors());
+
+      app.use(function(ctx) {
+        ctx.body = {foo: 'bar'};
+        const error = new Error('Whoops!');
+        error.headers = {Vary: 'Accept-Encoding'};
+        throw error;
+      });
+
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect('Vary', 'Accept-Encoding, Origin')
+        .expect(/Error/)
+        .expect(500, done);
     });
   });
 });


### PR DESCRIPTION
The default Koa error handling unsets headers on error, and picks headers from the Error (https://github.com/koajs/koa/blob/71aaa29591d6681f8579486f18d32ba1ee651a5b/lib/context.js#L141).
For the Vary Origin to be preserved on error it must be added to the Error.