### PR TITLE
Fix/non preflight options

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = function(options) {
       headersSet[key] = value;
     }
 
-    if (ctx.method !== 'OPTIONS') {
+    if (ctx.method !== 'OPTIONS' || !ctx.get('Access-Control-Request-Method')) {
       // Simple Cross-Origin Request, Actual Request, and Redirects
       set('Access-Control-Allow-Origin', origin);
 
@@ -97,15 +97,6 @@ module.exports = function(options) {
       }
     } else {
       // Preflight Request
-
-      // If there is no Access-Control-Request-Method header or if parsing failed,
-      // do not set any additional headers and terminate this set of steps.
-      // The request is outside the scope of this specification.
-      if (!ctx.get('Access-Control-Request-Method')) {
-        // this not preflight request, ignore it
-        return await next();
-      }
-
       ctx.set('Access-Control-Allow-Origin', origin);
 
       if (options.credentials === true) {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function(options) {
     // https://github.com/rs/cors/issues/10
     ctx.vary('Origin');
 
-    if (!requestOrigin) return await next();
+    if (!requestOrigin) await next();
 
     let origin;
     if (typeof options.origin === 'function') {

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -47,6 +47,7 @@ describe('cors.test.js', function() {
       request(app.listen())
         .options('/')
         .set('Origin', 'http://koajs.com')
+        .expect('Access-Control-Allow-Origin', 'http://koajs.com')
         .expect(200, done);
     });
 


### PR DESCRIPTION
Not all OPTIONS requests are CORS preflight requests from browsers. This middleware correctly checks to make sure that `Access-Control-Request-Method` is present before fully treating a request as a preflight-- however, it does so after skipping over any of the usual logic for "actual" requests.

The result is that access control headers will not be set for any OPTIONS requests, even though they will still continue into downstream middlewares like other "actual" requests:

https://github.com/koajs/cors/blob/71c4d00b170f52fd1324e9fd028816408867f8a6/index.js#L101-L107

This blocks any and all cross-origin OPTIONS requests that are not preflights, breaking features in other popular Koa middlewares-- such as the automatic 'allowed methods' middlewares from [koa-router](https://www.npmjs.com/package/koa-router).

I've fixed the problem by moving this check into the if statement that separates "actual" requests from preflight ones.

I've also removed some unnecessary `await` keywords, rationale explained here:

https://eslint.org/docs/rules/no-return-await

I can of course live without this second bit if you guys have some reason I'm not aware of for wanting to `return await` in these scenarios. Any performance change will be far below noticeable. I just figured I might as well, and can roll it back if I have to. :+1:

Thanks!

