### PR TITLE
Add support for using a function to determine whether or not to allow credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ app.use(cors());
  *  - {String|Array} exposeHeaders `Access-Control-Expose-Headers`
  *  - {String|Array} allowHeaders `Access-Control-Allow-Headers`
  *  - {String|Number} maxAge `Access-Control-Max-Age` in seconds
- *  - {Boolean} credentials `Access-Control-Allow-Credentials`
+ *  - {Boolean|Function(ctx)} credentials `Access-Control-Allow-Credentials`, default is false.
  *  - {Boolean} keepHeadersOnError Add set headers to `err.header` if an error is thrown
  * @return {Function} cors middleware
  * @api public

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ module.exports = function(options) {
     options.maxAge = String(options.maxAge);
   }
 
-  options.credentials = !!options.credentials;
   options.keepHeadersOnError = options.keepHeadersOnError === undefined || !!options.keepHeadersOnError;
 
   return async function cors(ctx, next) {
@@ -62,6 +61,13 @@ module.exports = function(options) {
       origin = options.origin || requestOrigin;
     }
 
+    let credentials;
+    if (typeof options.credentials === 'function') {
+      credentials = options.credentials(ctx);
+    } else {
+      credentials = !!options.credentials;
+    }
+
     const headersSet = {};
 
     function set(key, value) {
@@ -73,7 +79,7 @@ module.exports = function(options) {
       // Simple Cross-Origin Request, Actual Request, and Redirects
       set('Access-Control-Allow-Origin', origin);
 
-      if (options.credentials === true) {
+      if (credentials === true) {
         set('Access-Control-Allow-Credentials', 'true');
       }
 
@@ -108,7 +114,7 @@ module.exports = function(options) {
 
       ctx.set('Access-Control-Allow-Origin', origin);
 
-      if (options.credentials === true) {
+      if (credentials === true) {
         ctx.set('Access-Control-Allow-Credentials', 'true');
       }
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = function(options) {
     let credentials;
     if (typeof options.credentials === 'function') {
       credentials = options.credentials(ctx);
+      if (credentials instanceof Promise) credentials = await credentials;
     } else {
       credentials = !!options.credentials;
     }

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -271,6 +271,43 @@ describe('cors.test.js', function() {
     });
   });
 
+  describe('options.credentials unset', function() {
+    const app = new Koa();
+    app.use(cors());
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should disable Access-Control-Allow-Credentials on Simple request', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect({ foo: 'bar' })
+        .expect(200)
+        .end(function(error, response) {
+          if (error) return done(error);
+
+          const header = response.headers['access-control-allow-credentials'];
+          assert.equal(header, undefined, 'Access-Control-Allow-Credentials must not be set.');
+          done();
+        });
+    });
+
+    it('should disable Access-Control-Allow-Credentials on Preflight request', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'DELETE')
+        .expect(204)
+        .end(function(error, response) {
+          if (error) return done(error);
+
+          const header = response.headers['access-control-allow-credentials'];
+          assert.equal(header, undefined, 'Access-Control-Allow-Credentials must not be set.');
+          done();
+        });
+    });
+  });
   describe('options.allowHeaders', function() {
     it('should work with allowHeaders is string', function(done) {
       const app = new Koa();

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -372,8 +372,8 @@ describe('cors.test.js', function() {
   describe('options.credentials=async function', function() {
     const app = new Koa();
     app.use(cors({
-      async credentials(ctx) {
-        return ctx.url !== '/forbin';
+      async credentials() {
+        return true;
       },
     }));
     app.use(function(ctx) {

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -308,6 +308,67 @@ describe('cors.test.js', function() {
         });
     });
   });
+
+  describe('options.credentials=function', function() {
+    const app = new Koa();
+    app.use(cors({
+      credentials(ctx) {
+        return ctx.url !== '/forbin';
+      },
+    }));
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should enable Access-Control-Allow-Credentials on Simple request', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect('Access-Control-Allow-Credentials', 'true')
+        .expect({ foo: 'bar' })
+        .expect(200, done);
+    });
+
+    it('should enable Access-Control-Allow-Credentials on Preflight request', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'DELETE')
+        .expect('Access-Control-Allow-Credentials', 'true')
+        .expect(204, done);
+    });
+
+    it('should disable Access-Control-Allow-Credentials on Simple request', function(done) {
+      request(app.listen())
+        .get('/forbin')
+        .set('Origin', 'http://koajs.com')
+        .expect({ foo: 'bar' })
+        .expect(200)
+        .end(function(error, response) {
+          if (error) return done(error);
+
+          const header = response.headers['access-control-allow-credentials'];
+          assert.equal(header, undefined, 'Access-Control-Allow-Credentials must not be set.');
+          done();
+        });
+    });
+
+    it('should disable Access-Control-Allow-Credentials on Preflight request', function(done) {
+      request(app.listen())
+        .options('/forbin')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'DELETE')
+        .expect(204)
+        .end(function(error, response) {
+          if (error) return done(error);
+
+          const header = response.headers['access-control-allow-credentials'];
+          assert.equal(header, undefined, 'Access-Control-Allow-Credentials must not be set.');
+          done();
+        });
+    });
+  });
+
   describe('options.allowHeaders', function() {
     it('should work with allowHeaders is string', function(done) {
       const app = new Koa();

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -369,6 +369,36 @@ describe('cors.test.js', function() {
     });
   });
 
+  describe('options.credentials=async function', function() {
+    const app = new Koa();
+    app.use(cors({
+      async credentials(ctx) {
+        return ctx.url !== '/forbin';
+      },
+    }));
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should enable Access-Control-Allow-Credentials on Simple request', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect('Access-Control-Allow-Credentials', 'true')
+        .expect({ foo: 'bar' })
+        .expect(200, done);
+    });
+
+    it('should enable Access-Control-Allow-Credentials on Preflight request', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'DELETE')
+        .expect('Access-Control-Allow-Credentials', 'true')
+        .expect(204, done);
+    });
+  });
+
   describe('options.allowHeaders', function() {
     it('should work with allowHeaders is string', function(done) {
       const app = new Koa();


### PR DESCRIPTION
In some scenarios it's useful to allow credentials for certain domains but disallow credentials for others. For example, for a small set of trusted domains, sending credentials can allow authentication via cookies. Computing this via a function makes it possible to allow other non-trusted domains to still make cross-origin requests, but without credentials.

To enable this:
1. Added a test to confirm the default behavior of the credentials option. When unset the Access-Control-Allow-Credentials response header is not sent.
2. When options.credentials is a function, invoke the function to determine the value of the credentials option.
3. When an options.credentials function returns a Promise, await the promise.
4. When options.credentials is not a function, coerce the value into a boolean as before.

I also made a small change to the documentation to make clear that a function can now be provided.