### PR TITLE
add-secure-context-headers (Support SharedArrayBuffer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ app.use(cors());
  *  - {String|Number} maxAge `Access-Control-Max-Age` in seconds
  *  - {Boolean|Function(ctx)} credentials `Access-Control-Allow-Credentials`, default is false.
  *  - {Boolean} keepHeadersOnError Add set headers to `err.header` if an error is thrown
+ *  - {Boolean} secureContext `Cross-Origin-Opener-Policy` & `Cross-Origin-Embedder-Policy` headers.', default is false
  * @return {Function} cors middleware
  * @api public
  */

--- a/index.js
+++ b/index.js
@@ -13,12 +13,14 @@ const vary = require('vary');
  *  - {String|Number} maxAge `Access-Control-Max-Age` in seconds
  *  - {Boolean} credentials `Access-Control-Allow-Credentials`
  *  - {Boolean} keepHeadersOnError Add set headers to `err.header` if an error is thrown
+ *  - {Boolean} secureContext `Cross-Origin-Opener-Policy` & `Cross-Origin-Embedder-Policy` headers.', default is false
  * @return {Function} cors middleware
  * @api public
  */
 module.exports = function(options) {
   const defaults = {
     allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH',
+    secureContext: false,
   };
 
   options = {
@@ -43,7 +45,8 @@ module.exports = function(options) {
   }
 
   options.keepHeadersOnError = options.keepHeadersOnError === undefined || !!options.keepHeadersOnError;
-
+  options.secureContext = options.secureContext === undefined || !!options.secureContext;
+  
   return async function cors(ctx, next) {
     // If the Origin header is not present terminate this set of steps.
     // The request is outside the scope of this specification.
@@ -131,6 +134,11 @@ module.exports = function(options) {
 
       if (options.allowMethods) {
         ctx.set('Access-Control-Allow-Methods', options.allowMethods);
+      }
+
+      if (options.secureContext) {
+        set('Cross-Origin-Opener-Policy', 'same-origin');
+        set('Cross-Origin-Embedder-Policy', 'require-corp');
       }
 
       let allowHeaders = options.allowHeaders;

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -78,6 +78,51 @@ describe('cors.test.js', function() {
         .expect(200, done);
     });
   });
+const secureContextNotSet = (res) => {
+  if ('Cross-Origin-Opener-Policy' in res.headers) throw new Error("Cross-Origin-Opener-Policy should not be set");
+  if ('Cross-Origin-Embedder-Policy' in res.headers) throw new Error("'Cross-Origin-Embedder-Policy' should not be set");
+};
+const secureContextSet = (res) => {
+  if (!'Cross-Origin-Opener-Policy' in res.headers) throw new Error("Cross-Origin-Opener-Policy should  be set");
+  if (!'Cross-Origin-Embedder-Policy' in res.headers) throw new Error("'Cross-Origin-Embedder-Policy' should be set");
+};
+  describe('options.secureContext=true', function() {
+    const app = new Koa();
+    app.use(cors({
+      secureContext: true,
+    }));
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should always set `Cross-Origin-Opener-Policy` & `Cross-Origin-Embedder-Policy`', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect(secureContextSet)
+        .expect({ foo: 'bar' })
+        .expect(200, done);
+    });
+  });
+
+  describe('options.secureContext=false', function() {
+    const app = new Koa();
+    app.use(cors({
+      secureContext: false,
+    }));
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should not set `Cross-Origin-Opener-Policy` & `Cross-Origin-Embedder-Policy`', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect(secureContextNotSet)
+        .expect({ foo: 'bar' })
+        .expect(200, done);
+    });
+  });
 
   describe('options.origin=function', function() {
     const app = new Koa();


### PR DESCRIPTION
I am doing some work with webAssembly that requires `SharedArrayBuffer` on the client. This feature is restricted to origins that have particular secure-context headers set.  I believe this use case is distinct enough from other CORS settings that these headers should have their own flag.

Why is this required:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Planned_changes

Please take a look and let me know if any changes are required/suggested, thanks.

Edit: ~~Adding more tests now. I will take out of draft when they are in place.~~ Added unit tests, marked ready for review.