### PR TITLE
Add support for privateNetworkAccess, which add 'Access-Control-Allow-Private-Network' response header

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const vary = require('vary');
  *  - {Boolean|Function(ctx)} credentials `Access-Control-Allow-Credentials`
  *  - {Boolean} keepHeadersOnError Add set headers to `err.header` if an error is thrown
  *  - {Boolean} secureContext `Cross-Origin-Opener-Policy` & `Cross-Origin-Embedder-Policy` headers.', default is false
+ *  - {Boolean} privateNetworkAccess handle `Access-Control-Request-Private-Network` request by return `Access-Control-Allow-Private-Network`, default to false
  *    @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Planned_changes
  * @return {Function} cors middleware
  * @public
@@ -135,6 +136,10 @@ module.exports = function(options) {
 
       if (options.maxAge) {
         ctx.set('Access-Control-Max-Age', options.maxAge);
+      }
+
+      if (options.privateNetworkAccess && ctx.get('Access-Control-Request-Private-Network')) {
+        ctx.set('Access-Control-Allow-Private-Network', 'true');
       }
 
       if (options.allowMethods) {

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -698,4 +698,93 @@ describe('cors.test.js', function() {
         .expect(500, done);
     });
   });
+
+  describe('options.privateNetworkAccess=false', function() {
+    const app = new Koa();
+    app.use(cors({
+      privateNetworkAccess: false,
+    }));
+
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should not set `Access-Control-Allow-Private-Network` on not OPTIONS', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'PUT')
+        .expect(res => {
+          assert(!('Access-Control-Allow-Private-Network' in res.headers));
+        })
+        .expect(200, done);
+    });
+
+    it('should not set `Access-Control-Allow-Private-Network` if `Access-Control-Request-Private-Network` not exist on OPTIONS', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'PUT')
+        .expect(res => {
+          assert(!('Access-Control-Allow-Private-Network' in res.headers));
+        })
+        .expect(204, done);
+    });
+
+    it('should not set `Access-Control-Allow-Private-Network` if `Access-Control-Request-Private-Network` exist on OPTIONS', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'PUT')
+        .set('Access-Control-Request-Private-Network', 'true')
+        .expect(res => {
+          assert(!('Access-Control-Allow-Private-Network' in res.headers));
+        })
+        .expect(204, done);
+    });
+  });
+
+  describe('options.privateNetworkAccess=true', function() {
+    const app = new Koa();
+    app.use(cors({
+      privateNetworkAccess: true,
+    }));
+
+    app.use(function(ctx) {
+      ctx.body = { foo: 'bar' };
+    });
+
+    it('should not set `Access-Control-Allow-Private-Network` on not OPTIONS', function(done) {
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'PUT')
+        .expect(res => {
+          assert(!('Access-Control-Allow-Private-Network' in res.headers));
+        })
+        .expect(200, done);
+    });
+
+    it('should not set `Access-Control-Allow-Private-Network` if `Access-Control-Request-Private-Network` not exist on OPTIONS', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'PUT')
+        .expect(res => {
+          assert(!('Access-Control-Allow-Private-Network' in res.headers));
+        })
+        .expect(204, done);
+    });
+
+    it('should always set `Access-Control-Allow-Private-Network` if `Access-Control-Request-Private-Network` exist on OPTIONS', function(done) {
+      request(app.listen())
+        .options('/')
+        .set('Origin', 'http://koajs.com')
+        .set('Access-Control-Request-Method', 'PUT')
+        .set('Access-Control-Request-Private-Network', 'true')
+        .expect('Access-Control-Allow-Private-Network', 'true')
+        .expect(204, done);
+    });
+  });
+
 });


### PR DESCRIPTION
Add support for privateNetworkAccess options, which add 'Access-Control-Allow-Private-Network' response header when response to OPTIONS that has 'Access-Control-Request-Private-Network' request header

fix: https://github.com/koajs/cors/issues/81