### PR TITLE
[Proposal] fix: use friendlier promise checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,7 @@ module.exports = function(options) {
 
     let origin;
     if (typeof options.origin === 'function') {
-      origin = options.origin(ctx);
-      if (origin instanceof Promise) origin = await origin;
+      origin = await Promise.resolve().then(() => options.origin(ctx));
       if (!origin) return await next();
     } else {
       origin = options.origin || requestOrigin;
@@ -71,8 +70,7 @@ module.exports = function(options) {
 
     let credentials;
     if (typeof options.credentials === 'function') {
-      credentials = options.credentials(ctx);
-      if (credentials instanceof Promise) credentials = await credentials;
+      credentials = await Promise.resolve().then(() => options.credentials(ctx));
     } else {
       credentials = !!options.credentials;
     }

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function(options) {
 
     let origin;
     if (typeof options.origin === 'function') {
-      origin = await Promise.resolve().then(() => options.origin(ctx));
+      origin = await options.origin(ctx);
       if (!origin) return await next();
     } else {
       origin = options.origin || requestOrigin;
@@ -70,7 +70,7 @@ module.exports = function(options) {
 
     let credentials;
     if (typeof options.credentials === 'function') {
-      credentials = await Promise.resolve().then(() => options.credentials(ctx));
+      credentials = await options.credentials(ctx);
     } else {
       credentials = !!options.credentials;
     }

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -201,6 +201,37 @@ describe('cors.test.js', function() {
         .expect('Access-Control-Allow-Origin', '*')
         .expect(200, done);
     });
+
+    it('behaves correctly when the return type is promise-like', function(done) {
+      class WrappedPromise {
+        constructor(...args) {
+          this.internalPromise = new Promise(...args);
+        }
+
+        then(onFulfilled) {
+          this.internalPromise.then(onFulfilled);
+        }
+      }
+
+      const app = new Koa()
+        .use(cors({
+          origin() {
+            return new WrappedPromise(resolve => {
+              return resolve('*');
+            });
+          },
+        }))
+        .use(function(ctx) {
+          ctx.body = { foo: 'bar' };
+        });
+
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect({ foo: 'bar' })
+        .expect('Access-Control-Allow-Origin', '*')
+        .expect(200, done);
+    });
   });
 
   describe('options.exposeHeaders', function() {
@@ -448,6 +479,37 @@ describe('cors.test.js', function() {
         .set('Access-Control-Request-Method', 'DELETE')
         .expect('Access-Control-Allow-Credentials', 'true')
         .expect(204, done);
+    });
+
+    it('behaves correctly when the return type is promise-like', function(done) {
+      class WrappedPromise {
+        constructor(...args) {
+          this.internalPromise = new Promise(...args);
+        }
+
+        then(onFulfilled) {
+          this.internalPromise.then(onFulfilled);
+        }
+      }
+
+      const app = new Koa()
+        .use(cors({
+          credentials() {
+            return new WrappedPromise(resolve => {
+              resolve(true);
+            });
+          },
+        }))
+        .use(function(ctx) {
+          ctx.body = { foo: 'bar' };
+        });
+
+      request(app.listen())
+        .get('/')
+        .set('Origin', 'http://koajs.com')
+        .expect('Access-Control-Allow-Credentials', 'true')
+        .expect({ foo: 'bar' })
+        .expect(200, done);
     });
   });
 


### PR DESCRIPTION
## Motivation
The current syntax is not friendly to scenarios where the global `Promise` object may have been re-mapped to a different class, _and_ async functions are being used. Example:

```javascript
class WrappedPromise {
  // ...
}

global.Promise = WrappedPromise;

const asyncFunction = async () => 'something';

const result = asyncFunction();

console.log(result instanceof Promise);
```

This syntax should be more resilient against weird Promise scenarios, including this one.