### PR TITLE
Calling all options even if origin header is not present. Fix #18 - Not setting headers on Koa2 / Node 6.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,6 @@ module.exports = function(options) {
     // https://github.com/rs/cors/issues/10
     ctx.vary('Origin');
 
-    if (!requestOrigin) return await next();
-
     let origin;
     if (typeof options.origin === 'function') {
       origin = await options.origin(ctx);

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -77,6 +77,14 @@ describe('cors.test.js', function() {
         .expect({ foo: 'bar' })
         .expect(200, done);
     });
+
+    it('should always set `Access-Control-Allow-Origin` to *, even if no Origin is passed on request', function(done) {
+      request(app.listen())
+        .get('/')
+        .expect('Access-Control-Allow-Origin', '*')
+        .expect({ foo: 'bar' })
+        .expect(200, done);
+    });
   });
 
   describe('options.secureContext=true', function() {


### PR DESCRIPTION
Calling all options even if origin header is not present. Fix #18 - Not setting headers on Koa2 / Node 6.2

As Origin header is not set in all fetch. I understand that we need to be able to validade, even if the origin is not present. We are still following https://fetch.spec.whatwg.org/#http-origin but grating headers to be added to response on user needs(Options functions to be called). 

I even checked on https://expressjs.com/en/resources/middleware/cors.html  and I noticed, so far, that the handlers are called even though the request has no origin, Follow the request:

https://www.rfc-editor.org/rfc/rfc6454#section-7.3 

>  Whenever a user agent issues an HTTP request from a "privacy-
   sensitive" context, the user agent MUST send the value "null" in the
   Origin header field.

>  NOTE: This document does not define the notion of a privacy- sensitive context.  Applications that generate HTTP requests can  designate contexts as privacy-sensitive to impose restrictions on  how user agents generate Origin header fields.



Fixes #18

## Checklist

- [X] I have ensured my pull request is not behind the main or master branch of the original repository.
- [X] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [X] I have written a commit message that passes commitlint linting.
- [X] I have ensured that my code changes pass linting tests.
- [X] I have ensured that my code changes pass unit tests.
- [X] I have described my pull request and the reasons for code changes along with context if necessary.
